### PR TITLE
Port to aarch64 

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -6,7 +6,7 @@ use std::ffi::CString;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;
 
-use libc::{mount, c_void};
+use libc::{mount, c_void, c_char};
 
 use util::{path_to_cstring, as_path};
 use {OSError, Error};
@@ -83,9 +83,9 @@ impl Overlay {
         }
         options.push(b'\0');
         let rc = unsafe { mount(
-                b"overlay\0".as_ptr() as *const i8,
+                b"overlay\0".as_ptr() as *const c_char,
                 self.target.as_ptr(),
-                b"overlay\0".as_ptr() as *const i8,
+                b"overlay\0".as_ptr() as *const c_char,
                 0,
                 options.as_ptr() as *const c_void) };
         if rc < 0 {

--- a/src/remount.rs
+++ b/src/remount.rs
@@ -394,13 +394,13 @@ mod test {
 
     #[test]
     fn test_remount_unknown_mountpoint() {
-        let remount = Remount::new(OsStr::from_bytes(b"/\xff"));
+        let remount = Remount::new(OsStr::from_bytes("/\u{fffd}".as_bytes()));
         let error = remount.remount().unwrap_err();
         let Error(_, e, msg) = error;
         match e.get_ref() {
             Some(e) => {
                 assert_eq!(format!("{}", e), format!(
-                    "Cannot find mount point: {:?}", OsStr::from_bytes(b"/\xff")));
+                    "Cannot find mount point: {:?}", OsStr::from_bytes("/\u{fffd}".as_bytes())));
             },
             _ => panic!(),
         }

--- a/src/tmpfs.rs
+++ b/src/tmpfs.rs
@@ -4,7 +4,7 @@ use std::str::from_utf8;
 use std::ffi::CString;
 use std::path::Path;
 
-use libc::{c_void, uid_t, gid_t, mode_t};
+use libc::{c_void, uid_t, gid_t, mode_t, c_char};
 use libc::mount;
 use nix::mount::{self as flags, MsFlags};
 
@@ -117,9 +117,9 @@ impl Tmpfs {
         let mut options = self.format_options();
         options.push(0);
         let rc = unsafe { mount(
-                b"tmpfs\0".as_ptr() as *const i8,
+                b"tmpfs\0".as_ptr() as *const c_char,
                 self.target.as_ptr(),
-                b"tmpfs\0".as_ptr() as *const i8,
+                b"tmpfs\0".as_ptr() as *const c_char,
                 self.flags.bits(),
                 options.as_ptr() as *const c_void) };
         if rc < 0 {


### PR DESCRIPTION
Hello @tailhook, 
This fixes compilation on aarch64 by using `c_char` instead  of`i8`. 

I also fixed a test that was failing because `b"/\xff"` doesn't correspond to the string you were testing. 
Has nothing to do with the port, just wanted to see all tests passing before submitting the PR.  