### PR TITLE
Export mountinfo::MountInfoParser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use overlay::Overlay;
 pub use tmpfs::Tmpfs;
 pub use modify::Move;
 pub use remount::Remount;
+pub use mountinfo::{MountInfoParser, ParseError};
 
 quick_error! {
     #[derive(Debug)]


### PR DESCRIPTION
Hi, I'd like to use `MountInfoParser` and was hoping libmount could export it.