### PR TITLE
Update nix dependency to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 libc = "0.2.28"
-nix = "0.11"
+nix = "0.13"
 quick-error = "1.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
After checking the usage of the nix API, it looks to me like this change is semver compatible, so no major increment in the libmount crate version number should be required.