### PR TITLE
Update nix to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 libc = "0.2.28"
-nix = "0.13"
+nix = "0.14"
 quick-error = "1.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This is needed to fix breaking changes in libc on arm and s390x.
See: https://github.com/nix-rust/nix/pull/1055