### PR TITLE
update nix deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 libc = "0.2.28"
-nix = "0.14"
+nix = "0.21"
 quick-error = "1.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Update the `nix` dependency which as a know [CVE](https://nvd.nist.gov/vuln/detail/CVE-2021-45707). This might affect this crate directly, but it is one less vulnerability. The only affecting change is [this PR](https://github.com/nix-rust/nix/pull/1242). From my test it does not look like a breaking change for `glibc`.

Why this version:
1. It does not include the CVE
2. It is fully backward compatible, upgrading to >= 0.22 would cause trouble with the error.